### PR TITLE
PLAT-425: Upgrading gems to ruby 2.7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ rvm:
   - 2.6
   - 2.5
   - 2.4
-  - jruby
-  - truffleruby
 script: bundle exec rspec
 services:
   - redis-server

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,16 @@
+language: ruby
+cache: bundler
+rvm:
+  - 2.7.1
+  - 2.6
+  - 2.5
+  - 2.4
+sudo: false
 script: bundle exec rspec
 services:
   - redis-server
+
+before_install:
+  - gem update --system
+  # Update bundler to the latest
+  - gem install bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,17 @@
+language: ruby
+cache: bundler
+rvm:
+  - 2.7
+  - 2.6
+  - 2.5
+  - 2.4
+  - jruby
+  - truffleruby
 script: bundle exec rspec
 services:
   - redis-server
+sudo: false
+
+before_install:
+  - gem update --system
+  - gem install bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,3 @@
-language: ruby
-cache: bundler
-rvm:
-  - 2.7.1
-  - 2.6
-  - 2.5
-  - 2.4
-sudo: false
 script: bundle exec rspec
 services:
   - redis-server
-
-before_install:
-  - gem update --system
-  # Update bundler to the latest
-  - gem install bundler

--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,2 @@
-# A sample Gemfile
 source "https://rubygems.org"
-
-gem 'redis'
-group :developement do
-  gem 'rubocop'
-  gem 'byebug'
-end
-group :test do
-  gem 'rspec'
-end
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ihasa (1.1.1)
+    ihasa (1.1.2)
       redis (> 3)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,46 +1,34 @@
+PATH
+  remote: .
+  specs:
+    ihasa (1.1.1)
+      redis (> 3)
+
 GEM
   remote: https://rubygems.org/
   specs:
-    ast (2.4.0)
-    byebug (10.0.2)
     diff-lcs (1.3)
-    parallel (1.12.1)
-    parser (2.5.0.5)
-      ast (~> 2.4.0)
-    powerpack (0.1.1)
-    rainbow (3.0.0)
-    redis (4.0.1)
-    rspec (3.7.0)
-      rspec-core (~> 3.7.0)
-      rspec-expectations (~> 3.7.0)
-      rspec-mocks (~> 3.7.0)
-    rspec-core (3.7.1)
-      rspec-support (~> 3.7.0)
-    rspec-expectations (3.7.0)
+    redis (4.1.4)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
+    rspec-core (3.9.2)
+      rspec-support (~> 3.9.3)
+    rspec-expectations (3.9.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-mocks (3.7.0)
+      rspec-support (~> 3.9.0)
+    rspec-mocks (3.9.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-support (3.7.1)
-    rubocop (0.54.0)
-      parallel (~> 1.10)
-      parser (>= 2.5)
-      powerpack (~> 0.1)
-      rainbow (>= 2.2.2, < 4.0)
-      ruby-progressbar (~> 1.7)
-      unicode-display_width (~> 1.0, >= 1.0.1)
-    ruby-progressbar (1.9.0)
-    unicode-display_width (1.3.0)
+      rspec-support (~> 3.9.0)
+    rspec-support (3.9.3)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  byebug
-  redis
-  rspec
-  rubocop
+  ihasa!
+  rspec (~> 3.3)
 
 BUNDLED WITH
-   1.16.1
+   2.1.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,14 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    ast (2.4.0)
+    byebug (11.1.3)
     diff-lcs (1.3)
+    jaro_winkler (1.5.4)
+    parallel (1.19.1)
+    parser (2.7.1.2)
+      ast (~> 2.4.0)
+    rainbow (3.0.0)
     redis (4.1.4)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
@@ -22,13 +29,24 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.3)
+    rubocop (0.79.0)
+      jaro_winkler (~> 1.5.1)
+      parallel (~> 1.10)
+      parser (>= 2.7.0.1)
+      rainbow (>= 2.2.2, < 4.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 1.7)
+    ruby-progressbar (1.10.1)
+    unicode-display_width (1.6.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  byebug
   ihasa!
-  rspec (~> 3.3)
+  rspec (~> 3.9.0)
+  rubocop (~> 0.79.0)
 
 BUNDLED WITH
    1.17.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,14 +7,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    ast (2.4.0)
-    byebug (11.1.3)
     diff-lcs (1.3)
-    jaro_winkler (1.5.4)
-    parallel (1.19.1)
-    parser (2.7.1.2)
-      ast (~> 2.4.0)
-    rainbow (3.0.0)
     redis (4.1.4)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
@@ -29,24 +22,13 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.3)
-    rubocop (0.79.0)
-      jaro_winkler (~> 1.5.1)
-      parallel (~> 1.10)
-      parser (>= 2.7.0.1)
-      rainbow (>= 2.2.2, < 4.0)
-      ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 1.7)
-    ruby-progressbar (1.10.1)
-    unicode-display_width (1.6.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  byebug
   ihasa!
-  rspec (~> 3.9.0)
-  rubocop (~> 0.79.0)
+  rspec (~> 3.3)
 
 BUNDLED WITH
    2.1.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,4 +31,4 @@ DEPENDENCIES
   rspec (~> 3.3)
 
 BUNDLED WITH
-   2.1.4
+   1.17.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ GEM
       rspec-mocks (~> 3.9.0)
     rspec-core (3.9.2)
       rspec-support (~> 3.9.3)
-    rspec-expectations (3.9.1)
+    rspec-expectations (3.9.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-mocks (3.9.1)
@@ -49,4 +49,4 @@ DEPENDENCIES
   rubocop (~> 0.79.0)
 
 BUNDLED WITH
-   1.17.3
+   2.1.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,14 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    ast (2.4.0)
+    byebug (11.1.3)
     diff-lcs (1.3)
+    jaro_winkler (1.5.4)
+    parallel (1.19.1)
+    parser (2.7.1.2)
+      ast (~> 2.4.0)
+    rainbow (3.0.0)
     redis (4.1.4)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
@@ -22,13 +29,24 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.3)
+    rubocop (0.79.0)
+      jaro_winkler (~> 1.5.1)
+      parallel (~> 1.10)
+      parser (>= 2.7.0.1)
+      rainbow (>= 2.2.2, < 4.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 1.7)
+    ruby-progressbar (1.10.1)
+    unicode-display_width (1.6.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  byebug
   ihasa!
-  rspec (~> 3.3)
+  rspec (~> 3.9.0)
+  rubocop (~> 0.79.0)
 
 BUNDLED WITH
    2.1.4

--- a/ihasa.gemspec
+++ b/ihasa.gemspec
@@ -39,6 +39,6 @@ Gem::Specification.new do |s|
 
   s.summary = 'Redis-backed rate limiter (token bucket) written in Ruby and Lua'
 
-  s.add_runtime_dependency('redis', '~> 3')
-  s.add_development_dependency('rspec', '~> 3.4')
+  s.add_runtime_dependency('redis', '> 3')
+  s.add_development_dependency('rspec', '~> 3.3')
 end

--- a/ihasa.gemspec
+++ b/ihasa.gemspec
@@ -39,9 +39,6 @@ Gem::Specification.new do |s|
 
   s.summary = 'Redis-backed rate limiter (token bucket) written in Ruby and Lua'
 
-  s.add_runtime_dependency 'redis', '> 3'
-
-  s.add_development_dependency 'byebug'
-  s.add_development_dependency 'rspec', '~> 3.9.0'
-  s.add_development_dependency 'rubocop', '~> 0.79.0'
+  s.add_runtime_dependency('redis', '> 3')
+  s.add_development_dependency('rspec', '~> 3.3')
 end

--- a/ihasa.gemspec
+++ b/ihasa.gemspec
@@ -39,6 +39,9 @@ Gem::Specification.new do |s|
 
   s.summary = 'Redis-backed rate limiter (token bucket) written in Ruby and Lua'
 
-  s.add_runtime_dependency('redis', '> 3')
-  s.add_development_dependency('rspec', '~> 3.3')
+  s.add_runtime_dependency 'redis', '> 3'
+
+  s.add_development_dependency 'byebug'
+  s.add_development_dependency 'rspec', '~> 3.9.0'
+  s.add_development_dependency 'rubocop', '~> 0.79.0'
 end

--- a/lib/ihasa/version.rb
+++ b/lib/ihasa/version.rb
@@ -3,7 +3,7 @@
 module Ihasa
   # This module holds the Ihasa version information.
   module Version
-    STRING = '1.1.1'
+    STRING = '1.1.2'
 
     module_function
 

--- a/lib/ihasa/version.rb
+++ b/lib/ihasa/version.rb
@@ -3,7 +3,7 @@
 module Ihasa
   # This module holds the Ihasa version information.
   module Version
-    STRING = '1.1.2'
+    STRING = '1.1.1'
 
     module_function
 


### PR DESCRIPTION
https://art19co.atlassian.net/browse/PLAT-425

After messing up the git refs in the `schallereqo/rails-5` banch, it's probably safer for me to just branch the ruby 2.7 work itself from there, so here it is.